### PR TITLE
Fixed merge.recursive behavior

### DIFF
--- a/merge.js
+++ b/merge.js
@@ -31,7 +31,7 @@
 
 	Public.recursive = function(clone) {
 
-		return merge(clone === true, true, arguments);
+		return merge(clone === true, true, clone === true ? Array.prototype.slice.call(arguments, 1) : arguments);
 
 	};
 


### PR DESCRIPTION
Fixed merge.recursive behavior when first argument (clone) passed.