### PR TITLE
Use 'self' instead of 'window'

### DIFF
--- a/merge.js
+++ b/merge.js
@@ -168,7 +168,7 @@
 
 	} else {
 
-		window[publicName] = Public;
+		self[publicName] = Public;
 
 	}
 


### PR DESCRIPTION
Use 'self' instead of 'window' to make code compatible with Web Workers
